### PR TITLE
Readme: add usage description and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,27 @@ composer require coralic/kirby-extended-writer
 
 ## Usage
 
-`TODO`
+This plugin adds the mark `highlight` and the nodes `largerParagraph`, `h1`, `h2`, `h3`, `h4`, `h5` and `h6`.
+You can activate them in the writer field like this:
+
+```yaml
+text:
+  label: Text
+  type: writer
+  marks:
+    - bold
+    - italic
+    - link
+    - email
+    - highlight
+  nodes:
+    - h1
+    - h2
+    - h3
+    - largerParagraph
+    - bulletList
+    - orderedList
+```
 
 ## Credits
 


### PR DESCRIPTION
I added a description and an example to the usage section of the readme. I was a bit stumped myself when I started using the plugin last week because I didn't know about the `marks` and `nodes` settings of the writer field yet.